### PR TITLE
docs: fix grammar mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Devices report property data in the format defined in the product model to the p
        service_property = ServiceProperty()
        service_property.service_id = 'smokeDetector'
        service_property.properties = {'alarm': 10, 'smokeConcentration': 36, 'temperature': 64, 'humidity': 32}
-       services = [service_property.to_dict()]
+       services = [service_property]
    
        while True:
            device.get_client().report_properties(services, DefaultPublishActionListener())

--- a/README_CN.md
+++ b/README_CN.md
@@ -465,7 +465,7 @@ def run():
        service_property = ServiceProperty()
        service_property.service_id = 'smokeDetector'
        service_property.properties = {'alarm': 10, 'smokeConcentration': 36, 'temperature': 64, 'humidity': 32}
-       services = [service_property.to_dict()]
+       services = [service_property]
    
        while True:
            device.get_client().report_properties(services, DefaultPublishActionListener())


### PR DESCRIPTION
# What's the purpose of the change

The `Property Upload` section of README has a wrong example of code, which has an extra `to_dict` function